### PR TITLE
added size_limit in order to limit the size of a downloaded file from s3

### DIFF
--- a/ml_dronebase_utils/s3.py
+++ b/ml_dronebase_utils/s3.py
@@ -59,7 +59,8 @@ def download_s3_file(
         bucket_name (str): S3 bucket name.
         prefix (str): Relative path from bucket to requested file.
         local_path (str): Local directory to store file.
-        size_limit (int, optional): Limits the file size accepted to size_limit bytes. Default None.
+        size_limit (int, optional): Limits the file size accepted to size_limit bytes.
+        Default None.
     """
     s3 = boto3.client("s3")
     if size_limit is not None:
@@ -85,7 +86,8 @@ def download_s3_folder(
         bucket_name (str): S3 bucket name.
         prefix (str): Relative path from bucket to requested files.
         local_directory (str, optional): Local directory to store files in.
-        size_limit (int, optional): Limits the file size accepted to size_limit bytes. Default None.
+        size_limit (int, optional): Limits the file size accepted to size_limit bytes.
+        Default None.
     """
     s3 = boto3.resource("s3")
     bucket = s3.Bucket(bucket_name)


### PR DESCRIPTION
size_limit in both ```download_s3_file``` and ```download_s3_folder``` allow you to limit the file(s) downloaded by n bytes in order to avoid downloading incredibly large files (i.e., [Nova_Techren2](https://s3.console.aws.amazon.com/s3/object/db-insights-solar-data?region=us-east-2&prefix=insights/Nova/Nova_Techren2_20210802/Techren2_RGB.tiff) which is a 100GB ortho)