### PR TITLE
add sync_s3_folder

### DIFF
--- a/ml_dronebase_utils/s3.py
+++ b/ml_dronebase_utils/s3.py
@@ -113,3 +113,15 @@ def download_s3_folder(
             if obj.size > size_limit:
                 continue
         bucket.download_file(obj.key, target)
+
+
+def sync_s3_folder(bucket_name: str, prefix: str, local_directory: str) -> None:
+    """Download the contents of a folder directory in parallel using aws s3 sync.
+
+    Args:
+        bucket_name (str): S3 bucket name.
+        prefix (str): Relative path from bucket to requested files.
+        local_directory (str): Local directory to store files in.
+    """
+    os.makedirs(local_directory)
+    os.system(f"aws s3 sync s3://{bucket_name}/{prefix}/ {local_directory}")

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -2,4 +2,5 @@ def test_imports():
     from ml_dronebase_utils.s3 import download_s3_file  # noqa: F401
     from ml_dronebase_utils.s3 import download_s3_folder  # noqa: F401
     from ml_dronebase_utils.s3 import is_json  # noqa: F401
+    from ml_dronebase_utils.s3 import sync_s3_folder  # noqa: F401
     from ml_dronebase_utils.s3 import upload_dir  # noqa: F401


### PR DESCRIPTION
This PR adds `s3_sync_folder` which calls `aws s3 sync` which has the ability to download files in parallel. This was an issue I encountered when downloading the rooftops dataset which has many small files and `download_s3_folder` downloads files sequentially which is slow for a large number of files.